### PR TITLE
Feature/#24 asset 모듈 이동

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -24,14 +24,7 @@ repositories {
 }
 
 dependencies {
-    //s3
-    implementation 'software.amazon.awssdk:s3:2.37.5'
-    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.4.0")
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 
-    // Image Processing
-    implementation "com.sksamuel.scrimage:scrimage-core:4.0.32"
-    implementation "com.sksamuel.scrimage:scrimage-webp:4.0.32"
 
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/common/src/main/java/com/common/asset/image/domain/entity/ImageTarget.java
+++ b/common/src/main/java/com/common/asset/image/domain/entity/ImageTarget.java
@@ -1,5 +1,0 @@
-package com.common.asset.image.domain.entity;
-
-public enum ImageTarget {
-	USER, PRODUCT
-}

--- a/common/src/main/java/com/common/asset/image/infrastructure/dto/ImageUrlResponse.java
+++ b/common/src/main/java/com/common/asset/image/infrastructure/dto/ImageUrlResponse.java
@@ -1,4 +1,0 @@
-package com.common.asset.image.infrastructure.dto;
-
-public record ImageUrlResponse(String profileUrl) {
-}

--- a/domain-service/build.gradle
+++ b/domain-service/build.gradle
@@ -38,6 +38,16 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     runtimeOnly 'com.h2database:h2'
+
+
+    //s3
+    implementation 'software.amazon.awssdk:s3:2.37.5'
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.4.0")
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+
+    // Image Processing
+    implementation "com.sksamuel.scrimage:scrimage-core:4.0.32"
+    implementation "com.sksamuel.scrimage:scrimage-webp:4.0.32"
 }
 
 tasks.named('test') {

--- a/domain-service/src/main/java/com/domainservice/domain/asset/image/application/ImageCompressor.java
+++ b/domain-service/src/main/java/com/domainservice/domain/asset/image/application/ImageCompressor.java
@@ -1,4 +1,4 @@
-package com.common.asset.image.application;
+package com.domainservice.domain.asset.image.application;
 
 import java.io.File;
 import java.io.IOException;

--- a/domain-service/src/main/java/com/domainservice/domain/asset/image/application/ImageService.java
+++ b/domain-service/src/main/java/com/domainservice/domain/asset/image/application/ImageService.java
@@ -1,6 +1,6 @@
-package com.common.asset.image.application;
+package com.domainservice.domain.asset.image.application;
 
-import static com.common.asset.image.application.ImageUtils.*;
+import static com.domainservice.domain.asset.image.application.ImageUtils.*;
 import static java.nio.file.Files.*;
 
 import java.io.File;
@@ -14,10 +14,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.common.asset.image.domain.entity.Image;
-import com.common.asset.image.domain.entity.ImageTarget;
-import com.common.asset.image.domain.repository.ImageRepository;
-import com.common.asset.image.domain.service.AssetService;
+import com.domainservice.domain.asset.image.domain.entity.Image;
+import com.domainservice.domain.asset.image.domain.entity.ImageTarget;
+import com.domainservice.domain.asset.image.domain.repository.ImageRepository;
+import com.domainservice.domain.asset.image.domain.service.AssetService;
 import com.common.exception.CustomException;
 import com.common.exception.vo.FileExceptionCode;
 

--- a/domain-service/src/main/java/com/domainservice/domain/asset/image/application/ImageUtils.java
+++ b/domain-service/src/main/java/com/domainservice/domain/asset/image/application/ImageUtils.java
@@ -1,4 +1,4 @@
-package com.common.asset.image.application;
+package com.domainservice.domain.asset.image.application;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;

--- a/domain-service/src/main/java/com/domainservice/domain/asset/image/application/ProfileImageLoader.java
+++ b/domain-service/src/main/java/com/domainservice/domain/asset/image/application/ProfileImageLoader.java
@@ -1,12 +1,12 @@
-package com.common.asset.image.application;
+package com.domainservice.domain.asset.image.application;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.common.asset.image.domain.entity.Image;
-import com.common.asset.image.domain.service.AssetService;
-import com.common.asset.image.infrastructure.ProfileImageUploadClient;
-import com.common.asset.image.infrastructure.dto.ImageUrlResponse;
+import com.domainservice.domain.asset.image.domain.entity.Image;
+import com.domainservice.domain.asset.image.domain.service.AssetService;
+import com.domainservice.domain.asset.image.infrastructure.ProfileImageUploadClient;
+import com.domainservice.domain.asset.image.infrastructure.dto.ImageUrlResponse;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain-service/src/main/java/com/domainservice/domain/asset/image/domain/entity/Image.java
+++ b/domain-service/src/main/java/com/domainservice/domain/asset/image/domain/entity/Image.java
@@ -1,4 +1,4 @@
-package com.common.asset.image.domain.entity;
+package com.domainservice.domain.asset.image.domain.entity;
 
 import com.common.model.persistence.BaseEntity;
 

--- a/domain-service/src/main/java/com/domainservice/domain/asset/image/domain/entity/ImageTarget.java
+++ b/domain-service/src/main/java/com/domainservice/domain/asset/image/domain/entity/ImageTarget.java
@@ -1,0 +1,5 @@
+package com.domainservice.domain.asset.image.domain.entity;
+
+public enum ImageTarget {
+	USER, PRODUCT
+}

--- a/domain-service/src/main/java/com/domainservice/domain/asset/image/domain/repository/ImageRepository.java
+++ b/domain-service/src/main/java/com/domainservice/domain/asset/image/domain/repository/ImageRepository.java
@@ -1,10 +1,10 @@
-package com.common.asset.image.domain.repository;
+package com.domainservice.domain.asset.image.domain.repository;
 
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.common.asset.image.domain.entity.Image;
+import com.domainservice.domain.asset.image.domain.entity.Image;
 
 public interface ImageRepository extends JpaRepository<Image, String> {
 	Image save(Image image);

--- a/domain-service/src/main/java/com/domainservice/domain/asset/image/domain/service/AssetService.java
+++ b/domain-service/src/main/java/com/domainservice/domain/asset/image/domain/service/AssetService.java
@@ -1,4 +1,4 @@
-package com.common.asset.image.domain.service;
+package com.domainservice.domain.asset.image.domain.service;
 
 import org.springframework.web.multipart.MultipartFile;
 

--- a/domain-service/src/main/java/com/domainservice/domain/asset/image/infrastructure/ProfileImageUploadClient.java
+++ b/domain-service/src/main/java/com/domainservice/domain/asset/image/infrastructure/ProfileImageUploadClient.java
@@ -1,8 +1,8 @@
-package com.common.asset.image.infrastructure;
+package com.domainservice.domain.asset.image.infrastructure;
 
 import org.springframework.web.multipart.MultipartFile;
 
-import com.common.asset.image.infrastructure.dto.ImageUrlResponse;
+import com.domainservice.domain.asset.image.infrastructure.dto.ImageUrlResponse;
 
 public interface ProfileImageUploadClient {
 	ImageUrlResponse uploadImage(MultipartFile file);

--- a/domain-service/src/main/java/com/domainservice/domain/asset/image/infrastructure/api/ImageTestController.java
+++ b/domain-service/src/main/java/com/domainservice/domain/asset/image/infrastructure/api/ImageTestController.java
@@ -1,4 +1,4 @@
-package com.common.asset.image.infrastructure.api;
+package com.domainservice.domain.asset.image.infrastructure.api;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.common.asset.image.domain.service.AssetService;
-import com.common.asset.image.domain.entity.Image;
+import com.domainservice.domain.asset.image.domain.service.AssetService;
+import com.domainservice.domain.asset.image.domain.entity.Image;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain-service/src/main/java/com/domainservice/domain/asset/image/infrastructure/dto/ImageUrlResponse.java
+++ b/domain-service/src/main/java/com/domainservice/domain/asset/image/infrastructure/dto/ImageUrlResponse.java
@@ -1,0 +1,4 @@
+package com.domainservice.domain.asset.image.infrastructure.dto;
+
+public record ImageUrlResponse(String profileUrl) {
+}

--- a/domain-service/src/main/java/com/domainservice/domain/product/model/entity/Product.java
+++ b/domain-service/src/main/java/com/domainservice/domain/product/model/entity/Product.java
@@ -18,14 +18,6 @@ public class Product extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String description;
 
-    /*
-    ...
-     */
-
-    @Override
-    protected String getEntityPrefix() {
-        return "product"; // 해당 메서드를 통해 "product-UUID" 형태의 code가 자동 생성됨
-    }
 
     @Builder
     public Product(String title, String description) {
@@ -33,4 +25,8 @@ public class Product extends BaseEntity {
         this.description = description;
     }
 
+	@Override
+	protected String getEntitySuffix() {
+		return "";
+	}
 }

--- a/domain-service/src/main/resources/application.yml
+++ b/domain-service/src/main/resources/application.yml
@@ -2,6 +2,11 @@ spring:
   application:
     name: domain-service
 
+  profiles:
+    group:
+      local:
+        - secret
+
   datasource:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:domain_dev;MODE=MySQL # ?????? ???? ??
@@ -21,3 +26,9 @@ spring:
         highlight_sql: true
         use_sql_comments: true
         default_batch_fetch_size: 100
+
+custom:
+  image:
+    allowed-extension: jpg,jpeg,png,webp
+    max-size: 10485760 # 10mb
+    default: https://team03-ctrlz-5775efc3-b7e8.s3.ap-northeast-2.amazonaws.com/images/USER/defualt-profile-image.png


### PR DESCRIPTION
## 📌 개요
- asset 패키지를 domain-service로 이동시켰습니다.
- 이미지 파일을 관리를 위한 controller가 필요하다고 판단했습니다.

## ✨ 작업 내용
### s3와 이미지 압축을 위한 의존성을 추가했습니다.
<img width="592" height="396" alt="image" src="https://github.com/user-attachments/assets/ac40bc06-654d-4d3b-9c28-85bac73a7819" />

### s3 실행을 위한 설정을 추가했습니다. 
- application-secret.yml이 존재하고 local로 앱을 실행시키면 작동됩니다.
<img width="173" height="166" alt="image" src="https://github.com/user-attachments/assets/0fc3e8ef-2798-4c9a-91bb-bf51d442c189" />

<img width="767" height="84" alt="image" src="https://github.com/user-attachments/assets/4027fa05-f7b1-453e-8484-0fcffb5bb6f5" />


## 🧪 테스트 방법
- 앱 정상 실행 확인했습니다.

## 🔗 관련 이슈
close #24
