### PR TITLE
Docs/#225 swagger 작성 및 수정

### DIFF
--- a/account-service/account-application/src/main/resources/application-local.yml
+++ b/account-service/account-application/src/main/resources/application-local.yml
@@ -110,7 +110,10 @@ custom:
     max-size: 10485760 # 10mb
     default: https://team03-ctrlz-5775efc3-b7e8.s3.ap-northeast-2.amazonaws.com/images/USER/defualt-profile-image.png
 
-  redirectUrl: http://localhost:8000
+  feign:
+    domain-service: http://localhost:8081
+
+#  redirectUrl: http://localhost:8000
 
 logging:
   config: classpath:logback-local.xml

--- a/account-service/account-application/src/main/resources/application-local.yml
+++ b/account-service/account-application/src/main/resources/application-local.yml
@@ -110,8 +110,6 @@ custom:
     max-size: 10485760 # 10mb
     default: https://team03-ctrlz-5775efc3-b7e8.s3.ap-northeast-2.amazonaws.com/images/USER/defualt-profile-image.png
 
-  feign:
-    domain-service: http://localhost:8081
 
 #  redirectUrl: http://localhost:8000
 

--- a/ai-service/build.gradle
+++ b/ai-service/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     runtimeOnly project(":observability-config:zipkin")
     implementation project(":observability-config:logging")
 
+
     // actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     //ai
@@ -61,10 +62,9 @@ dependencies {
     //h2
     runtimeOnly 'com.h2database:h2'
 
-
-    if (project.hasProperty('profile') && project.property('profile') == 'local,secret') {
-        implementation 'org.springframework.ai:spring-ai-starter-model-transformers'
-    }
+//    if (project.hasProperty('profile') && project.property('profile') == 'local,secret') {
+    implementation 'org.springframework.ai:spring-ai-starter-model-transformers'
+//    }
 
     implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/ai-service/src/main/java/com/aiservice/controller/RecommendationController.java
+++ b/ai-service/src/main/java/com/aiservice/controller/RecommendationController.java
@@ -8,12 +8,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.aiservice.application.RecommendService;
 import com.aiservice.controller.dto.BaseResponse;
+import com.aiservice.docs.TriggerRecommendationApiDocs;
 import com.aiservice.domain.model.RecommendationResult;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-
+@Tag(name = "Ai-Service", description = "AI 추천 API")
 @Slf4j
 @RequiredArgsConstructor
 @RestController
@@ -22,6 +24,7 @@ public class RecommendationController {
 
 	private final RecommendService recommendService;
 
+	@TriggerRecommendationApiDocs
 	@GetMapping
 	public BaseResponse<RecommendationResult> triggerRecommendation(
 			@RequestParam("query") String query,

--- a/ai-service/src/main/java/com/aiservice/controller/RecommendationPollingController.java
+++ b/ai-service/src/main/java/com/aiservice/controller/RecommendationPollingController.java
@@ -9,12 +9,14 @@ import com.aiservice.application.SessionService;
 import com.aiservice.controller.dto.BaseResponse;
 import com.aiservice.domain.model.RecommendationResult;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * @Deprecated 프론트엔드 진행 작업에 따라 사용 여부가 달라집니다.
  */
+@Hidden
 @Slf4j
 @RestController
 @RequestMapping("/api/recommendations")

--- a/ai-service/src/main/java/com/aiservice/controller/RecommendationSseController.java
+++ b/ai-service/src/main/java/com/aiservice/controller/RecommendationSseController.java
@@ -9,12 +9,14 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.aiservice.application.SseCommunicationService;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * @Deprecated 프론트엔드 진행 작업에 따라 사용 여부가 달라집니다.
  */
+@Hidden
 @Slf4j
 @RestController
 @RequestMapping("/sse")

--- a/ai-service/src/main/java/com/aiservice/docs/TriggerRecommendationApiDocs.java
+++ b/ai-service/src/main/java/com/aiservice/docs/TriggerRecommendationApiDocs.java
@@ -1,0 +1,108 @@
+package com.aiservice.docs;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.aiservice.controller.dto.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "AI 상품 추천 요청 (Hybrid Search + LLM)",
+    description = """
+        사용자의 질문(Query)을 분석하여 하이브리드 검색을 수행하고, LLM을 통해 상품 추천 메시지를 생성합니다.
+        
+        ### 처리 과정
+        1. **제한 체크**: 사용자의 일일 추천 요청 횟수(`custom.recommendation.limit`) 도달 여부를 확인합니다.
+        2. **하이브리드 검색**: Vector Search와 Keyword Search를 결합하여 관련 상품 문서를 검색합니다.
+        3. **프롬프트 생성**: 검색된 상품 정보와 사용자 쿼리를 조합하여 LLM 프롬프트를 구성합니다.
+        4. **결과 반환**: 상품 링크가 포함된 추천 메시지를 반환하고, 세션 서비스에 이력을 저장합니다.
+        """
+)
+@Parameters({
+    @Parameter(
+        name = "query",
+        description = "사용자 검색어 (예: 가성비 좋은 아이폰 추천해줘)",
+        required = true,
+        in = ParameterIn.QUERY,
+        schema = @Schema(type = "string")
+    ),
+    @Parameter(
+        name = "X-REQUEST-ID",
+        description = "사용자 식별 ID (UUID)",
+        required = true,
+        in = ParameterIn.HEADER,
+        schema = @Schema(type = "string", example = "user-uuid-1234")
+    )
+})
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "요청 처리 성공 (결과 상태에 따라 분기)",
+        content = @Content(
+            schema = @Schema(implementation = BaseResponse.class),
+            examples = {
+                @ExampleObject(
+                    name = "성공 (OK)",
+                    description = "추천 상품을 찾고 LLM 메시지 생성에 성공한 경우",
+                    value = """
+                        {
+                          "data": {
+                            "status": "OK",
+                            "message": "안녕하세요! :blush: 아이폰을 찾고 계시군요! 아래는 추천드리는 아이폰 제품들입니다.\\n\\n1. [아이폰 14 (2228000원)](http://domain-svc:8081/api/products/019b28d5-4103-7a98-94d3-da1cf1bb6f10)\\n2. [아이폰 13 (2186000원)](http://domain-svc:8081/api/products/019b28d5-4103-7cfe-94d5-8cf8f9f46880)\\n3. [아이폰 SE (1517000원)](http://domain-svc:8081/api/products/019b28d5-4106-710d-a08d-095ebd1e3afe)\\n\\n좋은 선택 되시길 바랍니다! :sparkles:"
+                          },
+                          "message": "추천 생성 요청이 처리되었습니다."
+                        }
+                        """
+                ),
+                @ExampleObject(
+                    name = "제한 도달 (LIMIT_REACHED)",
+                    description = "설정된 추천 횟수 제한을 초과한 경우",
+                    value = """
+                        {
+                          "data": {
+                            "status": "LIMIT_REACHED",
+                            "message": "추천 횟수 제한에 도달했습니다."
+                          },
+                          "message": "추천 생성 요청이 처리되었습니다."
+                        }
+                        """
+                ),
+                @ExampleObject(
+                    name = "결과 없음 (NO_RESULTS)",
+                    description = "검색 결과가 없거나 적절한 추천을 찾지 못한 경우",
+                    value = """
+                        {
+                          "data": {
+                            "status": "NO_RESULTS",
+                            "message": "추천 상품을 찾지 못했습니다."
+                          },
+                          "message": "추천 생성 요청이 처리되었습니다."
+                        }
+                        """
+                )
+            }
+        )
+    ),
+    @ApiResponse(
+        responseCode = "400",
+        description = "잘못된 요청 (필수 파라미터 누락 등)",
+        content = @Content(schema = @Schema(hidden = true))
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "서버 내부 오류 (LLM 연동 실패 등)",
+        content = @Content(schema = @Schema(hidden = true))
+    )
+})
+public @interface TriggerRecommendationApiDocs {
+}

--- a/ai-service/src/main/java/com/aiservice/infrastructure/qdrant/configuration/VectorStoreConfiguration.java
+++ b/ai-service/src/main/java/com/aiservice/infrastructure/qdrant/configuration/VectorStoreConfiguration.java
@@ -1,36 +1,36 @@
-package com.aiservice.infrastructure.qdrant.configuration;
-
-import org.springframework.ai.embedding.EmbeddingModel;
-import org.springframework.ai.vectorstore.VectorStore;
-import org.springframework.ai.vectorstore.qdrant.QdrantVectorStore;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
-
-import io.qdrant.client.QdrantClient;
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
-@Profile("local || me")
-@Configuration
-public class VectorStoreConfiguration {
-
-	@Value("${vectorstore.qdrant.collection-name:test}")
-	private String collectionName;
-
-	@Value(("${vectorstore.qdrant.initialize-schema:true}"))
-	private boolean initializeSchema;
-
-
-	@Bean
-	public VectorStore qdrantVectorStore(QdrantClient qdrantClient, EmbeddingModel embeddingModel) {
-		log.info("Qdrant VectorStore 초기화 - Collection: {}, InitializeSchema: {}",
-				collectionName, initializeSchema);
-
-		return QdrantVectorStore.builder(qdrantClient, embeddingModel)
-				.collectionName(collectionName)
-				.initializeSchema(initializeSchema)
-				.build();
-	}
-}
+// package com.aiservice.infrastructure.qdrant.configuration;
+//
+// import org.springframework.ai.embedding.EmbeddingModel;
+// import org.springframework.ai.vectorstore.VectorStore;
+// import org.springframework.ai.vectorstore.qdrant.QdrantVectorStore;
+// import org.springframework.beans.factory.annotation.Value;
+// import org.springframework.context.annotation.Bean;
+// import org.springframework.context.annotation.Configuration;
+// import org.springframework.context.annotation.Profile;
+//
+// import io.qdrant.client.QdrantClient;
+// import lombok.extern.slf4j.Slf4j;
+//
+// @Slf4j
+// @Profile("local || me")
+// @Configuration
+// public class VectorStoreConfiguration {
+//
+// 	@Value("${vectorstore.qdrant.collection-name:test}")
+// 	private String collectionName;
+//
+// 	@Value(("${vectorstore.qdrant.initialize-schema:true}"))
+// 	private boolean initializeSchema;
+//
+//
+// 	@Bean
+// 	public VectorStore qdrantVectorStore(QdrantClient qdrantClient, EmbeddingModel embeddingModel) {
+// 		log.info("Qdrant VectorStore 초기화 - Collection: {}, InitializeSchema: {}",
+// 				collectionName, initializeSchema);
+//
+// 		return QdrantVectorStore.builder(qdrantClient, embeddingModel)
+// 				.collectionName(collectionName)
+// 				.initializeSchema(initializeSchema)
+// 				.build();
+// 	}
+// }

--- a/ai-service/src/main/java/com/aiservice/infrastructure/springDoc/SpringDocConfiguration.java
+++ b/ai-service/src/main/java/com/aiservice/infrastructure/springDoc/SpringDocConfiguration.java
@@ -10,15 +10,21 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.util.StreamUtils;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+
 
 @Configuration
 public class SpringDocConfiguration {
 
 	@Value("${openapi.service.url}")
 	private String gatewayUrl;
+
+	@Value("${server.port}")
+	private String localPort;
 
 	@Bean
 	public OpenAPI customOpenAPI() throws IOException {
@@ -27,11 +33,21 @@ public class SpringDocConfiguration {
 		String description = StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
 
 		return new OpenAPI()
+			.components(new Components()
+				.addSecuritySchemes("bearerAuth", new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)
+					.name("Authorization")))
 			.servers(
-				List.of(new Server().url(gatewayUrl).description("Gateway Server"))
+				List.of(
+					new Server().url(gatewayUrl).description("Gateway Server"),
+					new Server().url("http://localhost:" + localPort).description("local Server")
+				)
 			)
 			.info(new Info()
-				.title("연근마켓 - AI Service API")
+				.title("연근마켓 - Domain Service API")
 				.version("v1.0.0")
 				.description(description)
 			);

--- a/ai-service/src/main/resources/application-local.yml
+++ b/ai-service/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8084
+  port: 8088
 
 spring:
   application:
@@ -71,7 +71,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3308/domain_dev?rewriteBatchedStatements=true
+    url: jdbc:mysql://localhost:3307/domain_dev?rewriteBatchedStatements=true
     username: app
     password: 1234
 

--- a/domain-service/src/main/java/com/domainservice/common/exception/GlobalExceptionHandler.java
+++ b/domain-service/src/main/java/com/domainservice/common/exception/GlobalExceptionHandler.java
@@ -16,7 +16,7 @@ import com.common.exception.CustomException;
 import com.common.model.web.ErrorResponse;
 import com.domainservice.common.configuration.feign.exception.UserClientException;
 import com.domainservice.domain.post.post.exception.ProductPostException;
-import com.domainservice.domain.reivew.exception.ReviewException;
+import com.domainservice.domain.review.exception.ReviewException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 
 import lombok.RequiredArgsConstructor;

--- a/domain-service/src/main/resources/application.yml
+++ b/domain-service/src/main/resources/application.yml
@@ -1,98 +1,98 @@
-#application:
-#  title: yeongeunMarket
-#  version: 1.0
-#
-#server:
-#  port: 8081
-#
-#spring:
-#  application:
-#    name: domain-service
-#
-#  servlet:
-#    multipart:
-#      max-file-size: 10MB
-#      max-request-size: 10MB
-#
-#  datasource:
-#    driver-class-name: com.mysql.cj.jdbc.Driver
-#
-#  jpa:
-#    open-in-view: false
-#    hibernate:
-#      ddl-auto: create
-#    show-sql: false
-#    properties:
-#      hibernate:
-#        dialect: org.hibernate.dialect.MySQLDialect
-#        format_sql: true
-#        highlight_sql: true
-#        use_sql_comments: true
-#        default_batch_fetch_size: 100
-#      order_inserts: true
-#      order_updates: true
-#
-#  kafka:
-#    producer:
-#      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-#      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-#      properties:
-#        allow.auto.create.topics: false
-#        observation:
-#          enabled: true
-#
-#    consumer:
-#      group-id: domain-group
-#      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-#      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-#      properties:
-#        allow.auto.create.topics: false
-#        observation:
-#          enabled: true
-#
-#    listener:
-#      immediate-stop: false
-#
-#eureka:
-#  instance:
-#    prefer-ip-address: true
-#  client:
-#    enabled: true
-#
-#custom:
-#  image:
-#    allowed-extension: jpg,jpeg,png,webp
-#    max-size: 10485760 # 10mb
-#    default: https://team03-ctrlz-5775efc3-b7e8.s3.ap-northeast-2.amazonaws.com/images/USER/defualt-profile-image.png
-#
-#  config:
-#    topic-partitions: 1
-#    topic-replications: 1
-#
-#  cart:
-#    topic:
-#      command: cart-command
-#
-#  deposit:
-#    topic:
-#      command: deposit-command
-#
-#  product-post:
-#    topic:
-#      event: product-post-events
-#
-#  order:
-#    topic:
-#      command: order-command
-#
-#  search:
-#    topic:
-#      event: search-word-events
-#
-#springdoc:
-#  default-produces-media-type: application/json
-#  default-flat-param-object: true
-#  api-docs:
-#    path: /v3/api-docs
-#  swagger-ui:
-#    path: /swagger-ui.html
+application:
+  title: yeongeunMarket
+  version: 1.0
+
+server:
+  port: 8081
+
+spring:
+  application:
+    name: domain-service
+
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: create
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+        highlight_sql: true
+        use_sql_comments: true
+        default_batch_fetch_size: 100
+      order_inserts: true
+      order_updates: true
+
+  kafka:
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        allow.auto.create.topics: false
+        observation:
+          enabled: true
+
+    consumer:
+      group-id: domain-group
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        allow.auto.create.topics: false
+        observation:
+          enabled: true
+
+    listener:
+      immediate-stop: false
+
+eureka:
+  instance:
+    prefer-ip-address: true
+  client:
+    enabled: true
+
+custom:
+  image:
+    allowed-extension: jpg,jpeg,png,webp
+    max-size: 10485760 # 10mb
+    default: https://team03-ctrlz-5775efc3-b7e8.s3.ap-northeast-2.amazonaws.com/images/USER/defualt-profile-image.png
+
+  config:
+    topic-partitions: 1
+    topic-replications: 1
+
+  cart:
+    topic:
+      command: cart-command
+
+  deposit:
+    topic:
+      command: deposit-command
+
+  product-post:
+    topic:
+      event: product-post-events
+
+  order:
+    topic:
+      command: order-command
+
+  search:
+    topic:
+      event: search-word-events
+
+springdoc:
+  default-produces-media-type: application/json
+  default-flat-param-object: true
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html

--- a/gateway-service/src/main/resources/application-local.yml
+++ b/gateway-service/src/main/resources/application-local.yml
@@ -41,6 +41,13 @@ spring:
               filters:
                 - StripPrefix=1
 
+            - id: account-service
+              uri: lb://ACCOUNT-SERVICE
+              predicates:
+                - Path=/account-service/v3/api-docs/**
+              filters:
+                - StripPrefix=1
+
             - id: ai-service
               uri: lb://AI-SERVICE
               predicates:
@@ -247,6 +254,8 @@ springdoc:
         url: /payment-service/v3/api-docs
       - name: account-service
         url: /account-service/v3/api-docs
+      - name: ai-service
+        url: /ai-service/v3/api-docs
     path: /swagger-ui.html
 
 # k8s 설정

--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -41,6 +41,13 @@ spring:
               filters:
                 - StripPrefix=1
 
+            - id: account-service
+              uri: lb://ACCOUNT-SERVICE
+              predicates:
+                - Path=/account-service/v3/api-docs/**
+              filters:
+                - StripPrefix=1
+
             - id: ai-service
               uri: lb://AI-SERVICE
               predicates:
@@ -254,4 +261,8 @@ springdoc:
         url: /domain-service/v3/api-docs
       - name: payment-service
         url: /payment-service/v3/api-docs
+      - name: account-service
+        url: /account-service/v3/api-docs
+      - name: ai-service
+        url: /ai-service/v3/api-docs
     path: /swagger-ui.html

--- a/payment-service/src/main/java/com/paymentservice/payment/client/PaymentTossClient.java
+++ b/payment-service/src/main/java/com/paymentservice/payment/client/PaymentTossClient.java
@@ -105,6 +105,18 @@ public class PaymentTossClient {
         return response;
     }
 
+    // Entity없이 키값 만으로 취소하는 기능
+    public void cancelPayment(String paymentKey, String reason) {
+        try {
+            TossCancelRequest cancelRequest = new TossCancelRequest(null, reason); // 금액이 null이면 전액 취소
+            paymentFeignClient.refundPayment(paymentKey, cancelRequest, authHeader());
+            log.info("결제 취소(보상 트랜잭션) 성공: paymentKey={}, reason={}", paymentKey, reason);
+        } catch (Exception e) {
+            log.error("결제 취소(보상 트랜잭션) 실패 - 수동 환불 필요: paymentKey={}, reason={}", paymentKey, reason, e);
+            // 취소 실패는 Exception을 던지지 않고 로그만 남겨서 원본 에러(Exception e)가 묻히지 않게 함
+        }
+    }
+
     private String authHeader() {
         String key = (secretApiKey != null) ? secretApiKey : "test_secret_key";
         return "Basic " + Base64.getEncoder()

--- a/payment-service/src/main/java/com/paymentservice/payment/docs/ConfirmPaymentApiDocs.java
+++ b/payment-service/src/main/java/com/paymentservice/payment/docs/ConfirmPaymentApiDocs.java
@@ -53,7 +53,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
                     "paymentKey": "5zJ4xY7m0Kq...",
                     "orderId": "order-uuid-1234",
                     "amount": 50000,
-                    "usedDepositAmount": 10000
+                    "usedDepositAmount": 10000,
+                    "totalAmount": 40000
                 }
                 """
         )

--- a/payment-service/src/main/java/com/paymentservice/payment/docs/DepositPaymentApiDocs.java
+++ b/payment-service/src/main/java/com/paymentservice/payment/docs/DepositPaymentApiDocs.java
@@ -51,7 +51,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
                     "orderId": "order-uuid-9999",
                     "amount": 10000,
                     "usedDepositAmount": 10000,
-                    "paymentKey": "internal-deposit-key"
+                    "paymentKey": "internal-deposit-key",
+                    "totalAmount": 0
                 }
                 """
         )

--- a/payment-service/src/main/java/com/paymentservice/payment/service/PaymentService.java
+++ b/payment-service/src/main/java/com/paymentservice/payment/service/PaymentService.java
@@ -107,7 +107,8 @@ public class PaymentService {
 
         // 2차 검증: 토스에서 승인된 금액이 요청 금액과 일치하는지 확인
         // 프론트에서 금액을 다른 금액을 보냈다면 여기서 걸러지고 Exception 발생 -> Controller에서 catch -> cancelPayment 호출됨
-        if (approve.amount().compareTo(request.totalAmount()) != 0) {
+        BigDecimal sumAmount = request.totalAmount().add(request.usedDepositAmount());
+        if (approve.amount().compareTo(sumAmount) != 0) {
             throw new PaymentFailedException();
         }
 

--- a/payment-service/src/main/java/com/paymentservice/payment/service/PaymentService.java
+++ b/payment-service/src/main/java/com/paymentservice/payment/service/PaymentService.java
@@ -105,6 +105,12 @@ public class PaymentService {
     public PaymentResponse completeTossPayment(PaymentConfirmRequest request, String userId,
         Deposit deposit, TossApprovalResponse approve) {
 
+        // 2차 검증: 토스에서 승인된 금액이 요청 금액과 일치하는지 확인
+        // 프론트에서 금액을 다른 금액을 보냈다면 여기서 걸러지고 Exception 발생 -> Controller에서 catch -> cancelPayment 호출됨
+        if (approve.amount().compareTo(request.totalAmount()) != 0) {
+            throw new PaymentFailedException();
+        }
+
         try {
             // DB 저장 및 예치금 차감
             BigDecimal usedDepositAmount = approve.depositUsedAmount();     // deposit 사용 금액
@@ -146,7 +152,8 @@ public class PaymentService {
 
             return PaymentResponse.from(saved);
         } catch (Exception e) {
-            log.error("[토스 결제 실패] orderId={}, userId={}, paymentKey={}, request={}",
+            // 여기서 발생한 에러는 controller로 전파되어야 취소 로직이 수행
+            log.error("[토스 결제 후처리 실패] orderId={}, userId={}, paymentKey={}, request={}",
                 request.orderId(), userId, request.paymentKey(), request, e);
             throw new PaymentFailedException();
         }

--- a/payment-service/src/main/resources/application-local.yml
+++ b/payment-service/src/main/resources/application-local.yml
@@ -4,6 +4,8 @@ application:
 
 server:
   port: 8084
+  tomcat:
+    relaxed-query-chars: [ "[", "]" ]
 
 spring:
   application:


### PR DESCRIPTION
## 📌 개요
Payment 서비스의 결제 취소 로직 추가 및 Payment/AI 서비스의 API 명세서(Swagger) 현행화 작업을 수행했습니다.
> Payment 서비스에 `paymentKey` 기반 취소 기능을 구현하고, 신규 AI 서비스의 Swagger 설정을 완료하여 API 명세를 동기화했습니다.

---

## ✨ 주요 변경 사항

### 💳 Payment Service
- **결제 취소 로직 추가**: 기존 로직 외에 `paymentKey`만으로 결제를 취소할 수 있는 기능 구현

### 🤖 AI Service
- **Swagger 초기 설정**: `springdoc-openapi` 의존성 추가 및 Config 설정
- **API 명세 작성**:
  - `RecommendationController` API 명세 작성
  - 하이브리드 검색 및 추천 결과에 대한 응답 DTO 스키마 정의
  - 커스텀 어노테이션을 활용한 응답 예시(Success/Fail/Limit cases) 상세화

---

## 👀 리뷰어가 집중해서 봐줬으면 하는 부분
> **1. Payment 취소 로직**
> - `paymentKey`를 이용해 PG사 승인 취소 및 내부 주문 상태를 변경하는 로직이 올바르게 구현되었는지 검토 부탁드립니다.
>
> **2. AI Service 응답 예시**
> - Swagger UI에서 보이는 AI 추천 응답 메시지 예시가 프론트엔드에서 파싱하기에 적절한 구조인지 확인해 주시면 좋겠습니다.

---

## 🧪 테스트 방법
- [x] 로컬 환경(`local` profile)에서 각 서비스 구동 확인
- [x] **Payment Service**: `/swagger-ui/index.html` 접속 후 결제 취소 API 호출 테스트
- [x] **AI Service**: `/swagger-ui/index.html` 접속 후 추천 API 문서 확인

---

## 🧨 영향도 (Impact)
> 신규 API 추가 및 명세 변경으로 프론트엔드 연동 시 확인이 필요합니다.
- **Payment**: `paymentKey`를 활용한 단독 취소 API가 추가되었습니다.
- **AI**: 추천 기능 관련 엔드포인트 명세가 신규 생성되었습니다.

---

## 🔍 추가 고려 사항 (선택)
> AI 서비스의 응답 예시는 추후 LLM 연동 방식 고도화에 따라 포맷이 일부 변경될 수 있습니다.

---

## 🔗 관련 이슈
close #225 